### PR TITLE
Fix delete_methods

### DIFF
--- a/blinker/_saferef.py
+++ b/blinker/_saferef.py
@@ -161,13 +161,11 @@ class BoundMethodWeakref(object):
         """
         def remove(weak, self=self):
             """Set self.isDead to True when method or instance is destroyed."""
-            methods = self.deletion_methods[:]
-            del self.deletion_methods[:]
             try:
                 del self.__class__._all_instances[self.key]
             except KeyError:
                 pass
-            for function in methods:
+            for function in self.deletion_methods:
                 try:
                     if callable(function):
                         function(self)

--- a/blinker/_saferef.py
+++ b/blinker/_saferef.py
@@ -161,11 +161,13 @@ class BoundMethodWeakref(object):
         """
         def remove(weak, self=self):
             """Set self.isDead to True when method or instance is destroyed."""
+            methods = self.deletion_methods[:]
+            del self.deletion_methods
             try:
                 del self.__class__._all_instances[self.key]
             except KeyError:
                 pass
-            for function in self.deletion_methods:
+            for function in methods:
                 try:
                     if callable(function):
                         function(self)

--- a/blinker/base.py
+++ b/blinker/base.py
@@ -396,10 +396,7 @@ class Namespace(dict):
         Repeated calls to this function will return the same signal object.
 
         """
-        try:
-            return self[name]
-        except KeyError:
-            return self.setdefault(name, NamedSignal(name, doc))
+        return self.setdefault(name, NamedSignal(name, doc))
 
 
 class WeakNamespace(WeakValueDictionary):
@@ -417,10 +414,7 @@ class WeakNamespace(WeakValueDictionary):
         Repeated calls to this function will return the same signal object.
 
         """
-        try:
-            return self[name]
-        except KeyError:
-            return self.setdefault(name, NamedSignal(name, doc))
+        return self.setdefault(name, NamedSignal(name, doc))
 
 
 signal = Namespace().signal


### PR DESCRIPTION
Hi~ is there any need to `del self.delete_methods` here?
And actually `del self.delete_methods[:]` seems not do anything ,instead of copy the original list and delele the
reference . 

I guess that you just want deletion_methods work on  one of `self.weak_ref` and `self.weak_func` but not both.
It should be ok if using  `del self.delete_methods`
