### PR TITLE
Fixed memory leaks.

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -2,6 +2,10 @@
 Blinker Changelog
 =================
 
+Version 1.4.dev
+---------------
+
+- Fixed memory leaks.
 
 Version 1.3
 -----------


### PR DESCRIPTION
I found a big memory leaks in my project. After studying the problem I have identified the source of the leaks is a dictionaries `Signal._by_sender` and `Signal._by_receiver`.
I fixed this problem and create the pull request. Please, accept it and release new version of "blinker".