### PR TITLE
Speed up send() by 30% when there are no receivers.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,6 @@
-*.py?
+*.pyc
+*.c
+*.so
 *$py.class
 .coverage
 .tox
@@ -13,3 +15,4 @@ docs/pickles
 docs/source/_static
 docs/source/_template
 docs/website
+blinker.egg-info/

--- a/blinker/_speedup.pyx
+++ b/blinker/_speedup.pyx
@@ -1,0 +1,8 @@
+cdef class _CheckReceiversSignalMixin:
+    cdef public dict receivers
+
+    cdef __check_receivers(self):
+        return len(self.receivers) > 0
+
+    def _check_receivers(self):
+        return self.__check_receivers()

--- a/blinker/_speedup.pyx
+++ b/blinker/_speedup.pyx
@@ -1,8 +1,8 @@
 cdef class _CheckReceiversSignalMixin:
     cdef public dict receivers
 
-    cdef __check_receivers(self):
-        return len(self.receivers) > 0
+    cdef inline object __not_receivers(self):
+        return not self.receivers
 
-    def _check_receivers(self):
-        return self.__check_receivers()
+    def _not_receivers(self):
+        return self.__not_receivers()

--- a/blinker/base.py
+++ b/blinker/base.py
@@ -21,13 +21,19 @@ from blinker._utilities import (
     symbol,
     )
 
+try:
+    from ._speedup import _CheckReceiversSignalMixin
+except ImportError:
+    # None optimized class.
+    class _CheckReceiversSignalMixin:
+        def _check_receivers(self):
+            return len(self.receivers) > 0
 
 ANY = symbol('ANY')
 ANY.__doc__ = 'Token for "any sender".'
 ANY_ID = 0
 
-
-class Signal(object):
+class Signal(_CheckReceiversSignalMixin, object):
     """A notification emitter."""
 
     #: An :obj:`ANY` convenience synonym, allows ``Signal.ANY``
@@ -250,6 +256,9 @@ class Signal(object):
         :param \*\*kwargs: Data to be sent to receivers.
 
         """
+        if not self._check_receivers():
+            return []
+
         # Using '*sender' rather than 'sender=None' allows 'sender' to be
         # used as a keyword argument- i.e. it's an invisible name in the
         # function signature.
@@ -260,11 +269,9 @@ class Signal(object):
                             '%s given' % len(sender))
         else:
             sender = sender[0]
-        if not self.receivers:
-            return []
-        else:
-            return [(receiver, receiver(sender, **kwargs))
-                    for receiver in self.receivers_for(sender)]
+
+        return [(receiver, receiver(sender, **kwargs))
+                for receiver in self.receivers_for(sender)]
 
     def has_receivers_for(self, sender):
         """True if there is probably a receiver for *sender*.

--- a/blinker/base.py
+++ b/blinker/base.py
@@ -26,8 +26,8 @@ try:
 except ImportError:
     # None optimized class.
     class _CheckReceiversSignalMixin:
-        def _check_receivers(self):
-            return len(self.receivers) > 0
+        def _not_receivers(self):
+            return not self.receivers
 
 ANY = symbol('ANY')
 ANY.__doc__ = 'Token for "any sender".'
@@ -256,7 +256,7 @@ class Signal(_CheckReceiversSignalMixin, object):
         :param \*\*kwargs: Data to be sent to receivers.
 
         """
-        if not self._check_receivers():
+        if self._not_receivers():
             return []
 
         # Using '*sender' rather than 'sender=None' allows 'sender' to be

--- a/setup.py
+++ b/setup.py
@@ -3,6 +3,12 @@ try:
 except ImportError:
     from distutils.core import setup
 
+try:
+    from Cython.Build import cythonize
+    extensions = cythonize('blinker/_speedup.pyx')
+except ImportError:
+    extensions = None
+
 readme = open('README.md').read()
 import blinker
 version = blinker.__version__
@@ -10,6 +16,7 @@ version = blinker.__version__
 setup(name="blinker",
       version=version,
       packages=['blinker'],
+      ext_modules=extensions,
       author='Jason Kirtland',
       author_email='jek@discorporate.us',
       description='Fast, simple object-to-object and broadcast signaling',

--- a/tox.ini
+++ b/tox.ini
@@ -5,3 +5,5 @@ envlist = py25,py26,py27,py30,py31,py32,py33,py34,py35,jython
 deps=nose
 commands=nosetests
 
+[testenv:cython]
+deps=cython

--- a/tox.ini
+++ b/tox.ini
@@ -1,9 +1,16 @@
 [tox]
-envlist = py25,py26,py27,py30,py31,py32,py33,py34,py35,jython
+envlist = py25,py26,py27,py30,py31,py32,py33,py34,py35,jython,py36-cython,py27-cython
 
 [testenv]
 deps=nose
 commands=nosetests
 
-[testenv:cython]
-deps=cython
+[testenv:py36-cython]
+basepython = python3.6
+deps=nose,cython
+commands=nosetests
+
+[testenv:py27-cython]
+basepython = python2.7
+deps=nose,cython
+commands=nosetests


### PR DESCRIPTION
Use Cython if exists to speed up the checking if there are receivers. if Cython cant be found it uses a none optimized version.

A couple of considerations:

1) Cython module can be marked as required, speeding up all environments. But this is up to you.
2) The `TypeError` error raised when more than one sender is given as a param is done AFTER checking the availability of the receivers. it might broken a bit the contract.