### PR TITLE
add py36 to tox

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py25,py26,py27,py30,py31,py32,py33,py34,py35,jython
+envlist = py25,py26,py27,py30,py31,py32,py33,py34,py35,py36,jython
 
 [testenv]
 deps=nose


### PR DESCRIPTION
all tests worked.

also, py36 is already tested on travis, so why not also in tox.
if there is no such interpreter, tox will skip it.